### PR TITLE
Use Preact (compat) in place of React

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1,3 +1,6 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
 function MPPortrait({ mpData }) {
     return React.createElement('div', { className: 'mp-list' }, 
     React.createElement('a', { className: 'mp-container', href: `mp/${mpData.name.replaceAll(' ','_').toLowerCase()}_${mpData.province.toLowerCase()}`},
@@ -121,5 +124,4 @@ document.addEventListener('DOMContentLoaded', () => {
 });
   
 // Render the MPList component
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(React.createElement(MPList));
+ReactDOM.render(React.createElement(MPList), document.getElementById('root'));

--- a/public/js/mp-page.js
+++ b/public/js/mp-page.js
@@ -1,3 +1,6 @@
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
 let mpname = window.location.pathname.split('/')[2];
 
 function homeOwnerText(name, status) {
@@ -124,8 +127,10 @@ fetch(`/api/mp-data?name=${mpname}`)
     })
     .then(data => {
         // Render the MPList component
-        const root = ReactDOM.createRoot(document.getElementById('root'));
-        root.render(React.createElement(MPPortraitContainer, { mpData: data.mp[0], sheetData: data.sheet_data, disclosures: data.disclosures }));
+        ReactDOM.render(
+            React.createElement(MPPortraitContainer, { mpData: data.mp[0], sheetData: data.sheet_data, disclosures: data.disclosures }),
+            document.getElementById('root'),
+        );
     })
     .catch(error => {
         console.error('Error:', error);

--- a/views/_base.pug
+++ b/views/_base.pug
@@ -5,6 +5,7 @@ html(lang=`${lang}-ca`)
       meta(charset="utf-8")
       meta(name="viewport" content="width=device-width,initial-scale=1")
       title=title ? `${title} | ${siteTitle}` : siteTitle
+      script(type="importmap"): include importmap.json
       link(rel="stylesheet" href="/main.css")
       link(rel="stylesheet" href="/index.css")
   body

--- a/views/_react-scripts.pug
+++ b/views/_react-scripts.pug
@@ -1,2 +1,0 @@
-script(src="https://unpkg.com/react@18/umd/react.development.js")
-script(src="https://unpkg.com/react-dom@18/umd/react-dom.development.js")

--- a/views/importmap.json
+++ b/views/importmap.json
@@ -1,0 +1,9 @@
+{
+    "imports": {
+        "preact": "https://esm.sh/preact@10.23.1",
+        "preact/": "https://esm.sh/preact@10.23.1/",
+        "react": "https://esm.sh/preact@10.23.1/compat",
+        "react/": "https://esm.sh/preact@10.23.1/compat/",
+        "react-dom": "https://esm.sh/preact@10.23.1/compat"
+    }
+}

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,7 +1,6 @@
 extends _base
 
 append head
-  include _react-scripts
   script(type="module" src="index.js")
 
 block main

--- a/views/mp.pug
+++ b/views/mp.pug
@@ -1,7 +1,6 @@
 extends _base
 
 append head
-  include _react-scripts
   script(type="module" src="/js/mp-page.js")
 
 block main


### PR DESCRIPTION
Stacked onto #6 (branch _should_ update if/when that’s merged).

Since the usage of React is very simple here, we can replace React with Preact (compat). The only changes required here are to actually import `React`/`ReactDOM` where they are used, switch to the older `ReactDOM.render()` method, and add the import maps with the paths to Preact and the alias for `react` and `react-dom`.

In the future, we can optimize preloading as right now this will likely create a bit of a network waterfall. We could also explore using Preact without React compatibility, which would mean we’d be able to use `htm`’s JS template literals instead of the `React.createElement` calls.
