### PR TITLE
Partially implement MP card design

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -25,3 +25,101 @@
         margin-block-start: 3rem;
     }
 }
+
+@layer components {
+    .mp-cards-grid {
+        display: grid;
+        list-style: none;
+        padding-inline-start: 0;
+        column-gap: 24px; /* TODO */
+        row-gap: 16px;
+        justify-content: center;
+        grid-template-columns: repeat(auto-fill, minmax(345px, 1fr));
+    }
+
+    .mp-card {
+        grid-template-columns: [portrait-start] max(125px, 35%) [portrait-end content-start] auto [content-end];
+        column-gap: 8px;
+        background-color: #fff;
+        font-family: Courier New, system-ui, sans-serif;
+        position: relative;
+        border-block-start: 10px solid var(--party-color, #c0c0c0);
+        box-shadow: 0 0 15px rgb(0 0 0 / 0.15);
+    }
+
+    .mp-card:not([hidden]) {
+        display: grid;
+    }
+
+    .mp-card:where([data-party="Bloc Québécois"]) { --party-color: #0088ce; }
+    .mp-card:where([data-party="Conservative"]) { --party-color: #002395; }
+    .mp-card:where([data-party="Green"]) { --party-color: #427a26; }
+    .mp-card:where([data-party="Liberal"]) { --party-color: #d71920; }
+    .mp-card:where([data-party="NDP"]) { --party-color: #ff5800; }
+
+    .mp-card-content {
+        display: grid;
+        justify-items: start;
+        row-gap: 8px;
+        padding: 16px;
+        block-size: 100%;
+    }
+
+    .mp-card-title {
+        margin-block: 0;
+        font-size: 1.25rem;
+        font-weight: 700;
+    }
+
+    .mp-card-cta {
+        align-self: end;
+        text-underline-offset: 0.3em;
+        font-weight: 700;
+        color: #00e;
+    }
+
+    .mp-card-cta::after {
+        inset: 0;
+        position: absolute;
+        content: "";
+    }
+
+    .mp-card-content :not(.mp-card-cta) {
+        z-index: 1;
+    }
+
+    .mp-card-details {
+        display: grid;
+        justify-items: start;
+        row-gap: 16px;
+        margin-block: 0;
+    }
+
+    .mp-card-details :where(dt, dd) {
+        margin-inline-start: 0;
+    }
+
+    .mp-constituency-and-province {
+        display: grid;
+        row-gap: 4px;
+    }
+
+    .mp-portrait {
+        display: block;
+        inline-size: 100%;
+    }
+}
+
+@layer utilities {
+    .visually-hidden:not(:focus-within, :active) {
+        clip-path: inset(50%);
+        white-space: nowrap;
+        user-select: none;
+        border: 0;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        position: absolute;
+        overflow: hidden;
+    }
+}

--- a/public/main.css
+++ b/public/main.css
@@ -43,7 +43,7 @@
         background-color: #fff;
         font-family: Courier New, system-ui, sans-serif;
         position: relative;
-        border-block-start: 10px solid var(--party-color, #c0c0c0);
+        border-block-end: 10px solid var(--party-color, #c0c0c0);
         box-shadow: 0 0 15px rgb(0 0 0 / 0.15);
     }
 

--- a/views/index.js
+++ b/views/index.js
@@ -5,7 +5,7 @@ filterByProvince.addEventListener("input", filterResults);
 
 function filterResults(mp) {
     document.startViewTransition(() => {
-        for (const mp of document.querySelectorAll(".mp-list")) {
+        for (const mp of document.querySelectorAll(".mp-card")) {
             mp.hidden = 
                 filterByParty.value === "All" && filterByProvince.value === "All"
                     ? false

--- a/views/index.pug
+++ b/views/index.pug
@@ -21,17 +21,19 @@ block main
         select.filter-selector
           each province in ["All", "Ontario", "Quebec", "British Columbia", "Saskatchewan", "Alberta", "Manitoba", "Yukon", "Nova Scotia", "Newfoundland and Labrador", "New Brunswick", "Prince Edward Island", "Nunavut", "Northwest Territories"]
             option(value=province)=province
-      .mp-grid-container
+      ul.mp-cards-grid
         each mp in mps
-          .mp-list(data-province=mp.province data-party=mp.party style=`view-transition-name: ${mp.name.toLowerCase().replaceAll(" ", "_")}`)
-            a.mp-container(href=`mp/${mp.name.toLowerCase().replaceAll(" ", "_")}_${mp.province.toLowerCase()}`)
-              .flex
-                .img-container
-                  img.mp-img(src=`/images/mp_images/${mp.image_name}` alt="" loading="lazy")
-                .txt-container
-                  .top-tile
-                    p.mp-name=mp.name
-                    p(class=`mp-party ${mp.party.toLowerCase().replaceAll(" ", "-")}`)=mp.party
-                  .bottom-tile
-                    p.mp-constituency=mp.constituency
-                    p.mp-province=mp.province
+          - const mpNameSlug = mp.name.toLowerCase().replaceAll(" ", "_");
+          li.mp-card(data-province=mp.province data-party=mp.party style=`view-transition-name: ${mpNameSlug}`)
+            img.mp-portrait(src=`/images/mp_images/${mp.image_name}` alt="" loading="lazy")
+            .mp-card-content
+              h2.mp-card-title=mp.name
+              dl.mp-card-details
+                dt.visually-hidden Party
+                dd=mp.party
+                .mp-constituency-and-province
+                  dt.visually-hidden Constituency
+                  dd=mp.constituency
+                  dt.visually-hidden Province
+                  dd=mp.province
+              a.mp-card-cta(href=`mp/${mpNameSlug}_${mp.province.toLowerCase()}`) Learn more #[span.visually-hidden about #{mp.name}]


### PR DESCRIPTION
This is based off of the design shared in Discord. Not quite 1:1 parity, but I figure it was a good start. It also solves some of the other issues with the cards appearing so small (and with inconsistent widths), as well as some overflow issues. I will need to clean this up as right now my styles aren’t very well organized.

~This will need to be tested as my local data for MPs is missing some columns.~ It works.