### PR TITLE
Firefox Filtering Fix + Note about outdated Ontario Data + Filter by Riding for Federal MPS

### DIFF
--- a/views/index.js
+++ b/views/index.js
@@ -4,7 +4,26 @@ filterByParty.addEventListener("input", filterResults);
 filterByProvince.addEventListener("input", filterResults);
 
 function filterResults(mp) {
-    document.startViewTransition(() => {
+    // document.startViewTransition(() => {
+    //     for (const mp of document.querySelectorAll(".mp-card")) {
+    //         mp.hidden = 
+    //             filterByParty.value === "All" && filterByProvince.value === "All"
+    //                 ? false
+    //                 : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
+    //                   (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value);
+    //     }
+    // });
+    if (document.startViewTransition) {
+        document.startViewTransition(() => {
+            for (const mp of document.querySelectorAll(".mp-card")) {
+                mp.hidden = 
+                    filterByParty.value === "All" && filterByProvince.value === "All"
+                        ? false
+                        : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
+                          (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value);
+            }
+        });
+    } else {
         for (const mp of document.querySelectorAll(".mp-card")) {
             mp.hidden = 
                 filterByParty.value === "All" && filterByProvince.value === "All"
@@ -12,5 +31,5 @@ function filterResults(mp) {
                     : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
                       (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value);
         }
-    });
+    }
 }

--- a/views/index.js
+++ b/views/index.js
@@ -1,26 +1,29 @@
-const [filterByParty, filterByProvince] = document.querySelectorAll("select");
+const [filterByParty, filterByProvince, filterByConstituency] = document.querySelectorAll("select");
 
 filterByParty.addEventListener("input", filterResults);
 filterByProvince.addEventListener("input", filterResults);
+filterByConstituency.addEventListener("input", filterResults);
 
 function filterResults(mp) {
     if (document.startViewTransition) {
         document.startViewTransition(() => {
             for (const mp of document.querySelectorAll(".mp-card")) {
                 mp.hidden = 
-                    filterByParty.value === "All" && filterByProvince.value === "All"
+                    filterByParty.value === "All" && filterByProvince.value === "All" && filterByConstituency.value === "All"
                         ? false
                         : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
-                          (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value);
+                          (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value) ||
+                          (filterByConstituency.value !== "All" && mp.dataset.constituency !== filterByConstituency.value);
             }
         });
     } else {
         for (const mp of document.querySelectorAll(".mp-card")) {
             mp.hidden = 
-                filterByParty.value === "All" && filterByProvince.value === "All"
+                filterByParty.value === "All" && filterByProvince.value === "All" && filterByConstituency.value === "All"
                     ? false
                     : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
-                      (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value);
+                    (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value) ||
+                    (filterByConstituency.value !== "All" && mp.dataset.constituency !== filterByConstituency.value);
         }
     }
 }

--- a/views/index.js
+++ b/views/index.js
@@ -4,15 +4,6 @@ filterByParty.addEventListener("input", filterResults);
 filterByProvince.addEventListener("input", filterResults);
 
 function filterResults(mp) {
-    // document.startViewTransition(() => {
-    //     for (const mp of document.querySelectorAll(".mp-card")) {
-    //         mp.hidden = 
-    //             filterByParty.value === "All" && filterByProvince.value === "All"
-    //                 ? false
-    //                 : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
-    //                   (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value);
-    //     }
-    // });
     if (document.startViewTransition) {
         document.startViewTransition(() => {
             for (const mp of document.querySelectorAll(".mp-card")) {

--- a/views/index.pug
+++ b/views/index.pug
@@ -15,15 +15,15 @@ block main
       .sorting-container
         p.filter-text Select Party
         select.filter-selector
-          each party in ["All", "Conservative", "Liberal", "Independent", "Bloc Québécois", "NDP", "Green Party"]
+          each party in ["All", ...[...new Set(mps.map(mp => mp.party))].sort()]
             option(value=party)=party
         p.filter-text Select Province
         select.filter-selector
-          each province in ["All", "Ontario", "Quebec", "British Columbia", "Saskatchewan", "Alberta", "Manitoba", "Yukon", "Nova Scotia", "Newfoundland and Labrador", "New Brunswick", "Prince Edward Island", "Nunavut", "Northwest Territories"]
+          each province in ["All", ...[...new Set(mps.map(mp => mp.province))].sort()]
             option(value=province)=province
         p.filter-text Select Riding
         select.filter-selector
-          each constituency in ["All", ...mps.map(mp => mp.constituency)]
+          each constituency in ["All", ...mps.map(mp => mp.constituency).sort()]
             option(value=constituency)=constituency
       ul.mp-cards-grid
         each mp in mps

--- a/views/index.pug
+++ b/views/index.pug
@@ -21,10 +21,14 @@ block main
         select.filter-selector
           each province in ["All", "Ontario", "Quebec", "British Columbia", "Saskatchewan", "Alberta", "Manitoba", "Yukon", "Nova Scotia", "Newfoundland and Labrador", "New Brunswick", "Prince Edward Island", "Nunavut", "Northwest Territories"]
             option(value=province)=province
+        p.filter-text Select Riding
+        select.filter-selector
+          each constituency in ["All", ...mps.map(mp => mp.constituency)]
+            option(value=constituency)=constituency
       ul.mp-cards-grid
         each mp in mps
           - const mpNameSlug = mp.name.toLowerCase().replaceAll(" ", "_");
-          li.mp-card(data-province=mp.province data-party=mp.party style=`view-transition-name: ${mpNameSlug}`)
+          li.mp-card(data-province=mp.province data-party=mp.party data-constituency=mp.constituency style=`view-transition-name: ${mpNameSlug}`)
             img.mp-portrait(src=`/images/mp_images/${mp.image_name}` alt="" loading="lazy")
             .mp-card-content
               h2.mp-card-title=mp.name

--- a/views/ontario-index.pug
+++ b/views/ontario-index.pug
@@ -8,4 +8,6 @@ block main
   .title
     h1=ontarioSiteTitle
     p All data sourced from the #[a(href=pds.href)=pds.label]
+    p (NOTE: Data reflects the previous parliament, and is not up to date with the latest election.
+    p Once new ethics disclosures are filed, we will update this page.)
   #root


### PR DESCRIPTION
- Fixes startViewTransition breaking filtering on Firefox
- Adds a note about Ontario data being out of data now.
- Added a filter for filtering by riding for federal MPs (common request)
- Selection array for province / party / constituency is calculated dynamically