### PR TITLE
Use Node built-in env, add dev command, ESM, and other clean up

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,9 +80,9 @@ app.get('/about', (_req, res) => {
 app.get('/mp/:name', async (req, res) => {
     const { name } = req.params;
 
-    name_split = name.split("_");
-    province = name_split.pop(0);
-    final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
+    let name_split = name.split("_");
+    let province = name_split.pop(0);
+    let final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
 
     let mp = await MPS.findOne({ name: final_name_sanitized, province: province }, COLLATION);
     let { home_owner, landlord, investor } = await SHEET_DATA.findOne({ name: final_name_sanitized }, COLLATION);
@@ -101,8 +101,8 @@ app.get('/mp/:name', async (req, res) => {
 app.get('/mpp/:name', async (req, res) => {
     const { name } = req.params;
 
-    name_split = name.split("_");
-    final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
+    let name_split = name.split("_");
+    let final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
 
     let mpp = await ONTARIO_MPPS.findOne({ name: final_name_sanitized }, COLLATION);
     let disclosures = await ONTARIO_DISCLOSURES.find({ name: final_name_sanitized }, COLLATION).sort({ category: 1 }).toArray();
@@ -120,8 +120,8 @@ app.get('/mpp/:name', async (req, res) => {
 app.get('/mla/:name', async (req, res) => {
     const { name } = req.params;
 
-    name_split = name.split("_");
-    final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
+    let name_split = name.split("_");
+    let final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
 
     let mla = await ALBERTA_MLAS.findOne({ name: final_name_sanitized }, COLLATION);
     let disclosures = await ALBERTA_DISCLOSURES.find({ name: final_name_sanitized }, COLLATION).sort({ category: 1 }).toArray();
@@ -129,7 +129,7 @@ app.get('/mla/:name', async (req, res) => {
     let homeowner = false;
     let landlord = false;
     let investor = false;
-    for (i=0; i<disclosures.length;++i) {
+    for (let i=0; i<disclosures.length;++i) {
         if (disclosures[i]['category'] == 'Property') {
             homeowner = true;
         }
@@ -163,8 +163,8 @@ app.get('/mla/:name', async (req, res) => {
 app.get('/mna/:name', async (req, res) => {
     const { name } = req.params;
 
-    name_split = name.split("_");
-    final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
+    let name_split = name.split("_");
+    let final_name_sanitized = name_split.join(" ").replace(/[^a-zA-Z0-9\u00E0-\u00FC\u00E8-\u00EB\u0152\u0153\u00C0-\u00FC\u00C8-\u00CB\u0152. '-]/g, '');
 
     let mna = await QUEBEC_MNAS.findOne({ name: final_name_sanitized }, COLLATION);
     let disclosures = await QUEBEC_DISCLOSURES.find({ name: final_name_sanitized }, COLLATION).sort({ category: 1 }).toArray();
@@ -174,7 +174,7 @@ app.get('/mna/:name', async (req, res) => {
     let investor = false;
     // Revenu de location = landlord
     // résidentielles personnelles = homeowner
-    for (i=0; i<disclosures.length;++i) {
+    for (let i=0; i<disclosures.length;++i) {
         if (disclosures[i]['content'].includes('résidentielles personnelles')) {
             homeowner = true;
         }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import express from "express";
 import { MongoClient } from "mongodb";
-import { createServer } from "http";
 import path from "path";
 import pug from "pug";
 
@@ -25,7 +24,6 @@ const QUEBEC_DISCLOSURES = database.collection('quebec_disclosures');
 const COLLATION = { collation : {locale: "fr_CA", strength: 2 }}
 
 const app = express();
-createServer(app);
 
 app.set('view engine', 'pug');
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import express from "express";
 import { MongoClient } from "mongodb";
-import path from "path";
 import pug from "pug";
 
 const uri = process.env.MONGO_URI;
@@ -206,7 +205,8 @@ app.get('/mna/:name', async (req, res) => {
     });
 });
 
-app.use(express.static(path.join(import.meta.dirname, 'public')));
+const assetURL = new URL(import.meta.resolve("./public"));
+app.use(express.static(assetURL.pathname));
 
 app.get('/api/mps-data', async (_req, res) => {
     try {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
-require('dotenv').config(); //initialize dotenv
+import express from "express";
+import { MongoClient } from "mongodb";
+import { createServer } from "http";
+import path from "path";
+import pug from "pug";
 
-const { MongoClient } = require("mongodb");
 const uri = process.env.MONGO_URI;
 
 const dbClient = new MongoClient(uri);
@@ -21,11 +24,8 @@ const QUEBEC_DISCLOSURES = database.collection('quebec_disclosures');
 
 const COLLATION = { collation : {locale: "fr_CA", strength: 2 }}
 
-const express = require('express');
 const app = express();
-const http = require('http').createServer(app);
-const path = require('path');
-const pug = require('pug');
+createServer(app);
 
 app.set('view engine', 'pug');
 
@@ -208,7 +208,7 @@ app.get('/mna/:name', async (req, res) => {
     });
 });
 
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(import.meta.dirname, 'public')));
 
 app.get('/api/mps-data', async (_req, res) => {
     try {
@@ -253,7 +253,7 @@ app.get('/robots.txt', function (_req, res) {
 });
 
 const PORT = process.env.PORT || 3000;
-http.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,7 @@
       "dependencies": {
         "express": "^4.21.2",
         "mongodb": "^6.13.0",
-        "pug": "^3.0.3",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "pug": "^3.0.3"
       },
       "devDependencies": {
         "@flydotio/dockerfile": "^0.7.4"
@@ -1256,25 +1254,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1327,11 +1306,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="
     },
     "node_modules/send": {
       "version": "0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "mongodb": "^6.13.0",
         "pug": "^3.0.3",
@@ -411,17 +410,6 @@
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
       "license": "MIT"
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "mplandlordchecker",
   "version": "1.0.0",
   "description": "Check if your MP is a landlord.",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "test": "npm test",
-    "start": "node index.js"
+    "start": "node --env-file=.env index.js",
+    "dev": "node --env-file=.env --watch index.js"
   },
   "keywords": [
     "mp"
@@ -13,7 +15,6 @@
   "author": "OmegaSheep",
   "license": "ISC",
   "dependencies": {
-    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "mongodb": "^6.13.0",
     "pug": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
   "dependencies": {
     "express": "^4.21.2",
     "mongodb": "^6.13.0",
-    "pug": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "pug": "^3.0.3"
   },
   "devDependencies": {
     "@flydotio/dockerfile": "^0.7.4"


### PR DESCRIPTION
This pull request is only developer experience focused. It does six things:

1. Uses Node’s built-in support for environment variable files with the `--env-file` CLI flag and drops the `dotenv` dependency.
2. Switches from CommonJS to ESM.
3. Adds a `dev` script which uses the newer built-in `--watch` CLI flag. This means changes to `index.js` will restart the development server.
4. Removes an unnecessary usage of `http`’s `createServer()` with the Express app object.
5. Removes the React dependency from `package.json`.
6. Removes the `path` usage and uses `import.meta.resolve()` instead since we’re inside of a module now.
