### PR TITLE
[Critical] Respect reduced motion for filter view transition

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -14,7 +14,9 @@
 
     header nav {
         display: inline-flex;
+        flex-wrap: wrap;
         column-gap: 1rem;
+        row-gap: 0.5rem;
     }
 
     header nav a[aria-current="page"] {

--- a/views/index.css
+++ b/views/index.css
@@ -1,7 +1,5 @@
-@media (prefers-reduced-motion) {
-    @view-transition {
-        navigation: auto;
-    }
+@view-transition {
+    navigation: auto;
 }
 
 :root {

--- a/views/index.css
+++ b/views/index.css
@@ -5,3 +5,9 @@
 :root {
     scrollbar-gutter: stable;
 }
+
+.sorting-container select {
+    /* Fallback for field-sizing */
+    max-inline-size: 100%;
+    field-sizing: content;
+}

--- a/views/index.js
+++ b/views/index.js
@@ -1,29 +1,21 @@
-const [filterByParty, filterByProvince, filterByConstituency] = document.querySelectorAll("select");
+const ALL = document.documentElement.lang === "fr-ca" ? "Toutes" : "All";
+const controls = [filterByParty, filterByProvince, filterByConstituency] = document.querySelectorAll("select");
 
-filterByParty.addEventListener("input", filterResults);
-filterByProvince.addEventListener("input", filterResults);
-filterByConstituency.addEventListener("input", filterResults);
+for (const control of controls) control.addEventListener("input", filterResults)
 
 function filterResults(mp) {
-    if (document.startViewTransition) {
-        document.startViewTransition(() => {
-            for (const mp of document.querySelectorAll(".mp-card")) {
-                mp.hidden = 
-                    filterByParty.value === "All" && filterByProvince.value === "All" && filterByConstituency.value === "All"
-                        ? false
-                        : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
-                          (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value) ||
-                          (filterByConstituency.value !== "All" && mp.dataset.constituency !== filterByConstituency.value);
-            }
-        });
-    } else {
+    if (matchMedia("not (prefers-reduced-motion)").matches) filter();
+    document.startViewTransition?.(filter) ?? filter();
+
+    function filter() {
         for (const mp of document.querySelectorAll(".mp-card")) {
             mp.hidden = 
-                filterByParty.value === "All" && filterByProvince.value === "All" && filterByConstituency.value === "All"
-                    ? false
-                    : (filterByProvince.value !== "All" && mp.dataset.province !== filterByProvince.value) ||
-                    (filterByParty.value !== "All" && mp.dataset.party !== filterByParty.value) ||
-                    (filterByConstituency.value !== "All" && mp.dataset.constituency !== filterByConstituency.value);
+                filterByParty.value === ALL && filterByProvince.value === ALL && filterByConstituency.value === ALL
+                ? false
+                : (filterByProvince.value !== ALL && mp.dataset.province !== filterByProvince.value) ||
+                  (filterByParty.value !== ALL && mp.dataset.party !== filterByParty.value) ||
+                  (filterByConstituency.value !== ALL && mp.dataset.constituency !== filterByConstituency.value);
         }
     }
 }
+


### PR DESCRIPTION
I made a bad assumption about how an API worked and, even worse, didn’t test that the view transitions for the federal MP list don’t run for reduced motion. The media query I wrote for it was also reverse what it should have been anyway, but it was still working which leads me to believe they don’t work at all with the `@view-transition` at-rule (come to think of it, I think that rule might only work for multi-page view transitions). Anyway, this fixes the whole thing to check the reduced motion preference before calling starting the view transition with JS.

Also, since I had the change already made, it also sets the stage for the filter to work when the page is localized en français and fixes a couple of overflow issues I noticed for mobile since we’ve added the data for more provinces and added the constituency filter.
