### PR TITLE
Include landlord data for cards + add table

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,53 +56,51 @@ app.use((req, res, next) => {
 });
 
 app.get('/', async (_req, res) => {
-    let mps = await MPS.find({ }).sort({ name: 1 }).toArray();
+    let mps = await MPS.aggregate([
+        {
+            $lookup: {
+                from: "sheet_data",
+                localField: "name",
+                foreignField: "name",
+                as: "sheet_data_matches"
+            },
+        },
+        {
+            $replaceRoot: {
+                newRoot: {
+                    $mergeObjects: [ { $arrayElemAt: [ "$sheet_data_matches", 0 ] }, "$$ROOT" ],
+                },
+            },
+        },
+        {
+            $project: { sheet_data_matches: 0 },
+        },
+    ]).sort({ name: 1 }).toArray();
 
-    async function getPartyLandlordCount(partyName) {
-        let landlordTotal = await MPS.aggregate([
-            {
-              $match: { party: partyName }
-            },
-            {
-              $lookup: {
-                from: 'sheet_data',
-                let: { name: '$name' },
-                pipeline: [
-                  { $match: { 
-                    $expr: {
-                      $and: [
-                        { $eq: ['$$name', '$name'] },
-                        { $eq: ['$landlord', 'Y']}
-                      ]
-                    }
-                  }}
-                ],
-                as: 'sheet_data_match'
-              }
-            },
-            {
-              $match: { 'sheet_data_match.0': { $exists: true } }
-            },
-            {
-              $count: 'total'
+    const parties = new Map();
+    let totalMps = 0;
+    let totalLandlords = 0;
+
+    for (const mp of mps) {
+        mp.landlord = mp.landlord === "Y";
+        mp.homeowner = mp.home_owner === "Y";
+        delete mp.home_owner;
+        mp.investor = mp.investor === "Y";
+
+        if (mp.party != null) {
+            const party = parties.get(mp.party) ?? parties.set(mp.party, { mps: 0, landlords: 0 }).get(mp.party);
+
+            party.mps++;
+            totalMps++;
+
+            if (mp.landlord) {
+                party.landlords++;
+                totalLandlords++;
             }
-        ]).toArray();
-        let mpTotal = await MPS.countDocuments({ party: partyName });
-        return [landlordTotal[0].total, mpTotal];
+        }
     }
 
-    let [libCount, conCount, ndpCount, blocCount, greenCount, indyCount] = await Promise.all([
-        getPartyLandlordCount('Liberal'),
-        getPartyLandlordCount('Conservative'),
-        getPartyLandlordCount('NDP'),
-        getPartyLandlordCount('Bloc Québécois'),
-        getPartyLandlordCount('Green Party'),
-        getPartyLandlordCount('Independent'),
-    ]);
-
-    // TODO: Make this less horrible.
-    let totalCount = [libCount[0] + conCount[0] + ndpCount[0] + blocCount[0] + greenCount[0] + indyCount[0], libCount[1] + conCount[1] + ndpCount[1] + blocCount[1] + greenCount[1] + indyCount[1]]
-    res.render('index', { mps, partyCounts: [libCount, conCount, ndpCount, blocCount, greenCount, indyCount, totalCount] });
+    res.render('index', { mps, parties, totalMps, totalLandlords });
 });
 
 app.get('/ontario', (_req, res) => {

--- a/public/index.css
+++ b/public/index.css
@@ -19,13 +19,11 @@ a.invis{
     text-align: center;
     color: black;
     font-weight: bolder;
-    font-family: "Gill Sans Extrabold", sans-serif;
 }
 
 .contact {
     text-align: center;
     color: black;
-    font-family: "Consolas", sans-serif;
 }
 
 .mp-list:not([hidden]) {
@@ -82,12 +80,7 @@ a.invis{
 
 .category {
     font-weight: bolder;
-    font-family: 'Arial', Courier, monospace;
     font-size: 12;
-}
-
-.disclosure {
-    font-family: 'Arial', Courier, monospace;
 }
 
 .disclosure-container {
@@ -172,7 +165,6 @@ a.invis{
 }
 
 body {
-    font-family: 'Arial', Courier, monospace;
     background-color: #F2F2F2;
     max-width: 1200px;
     margin: 0 auto;

--- a/public/main.css
+++ b/public/main.css
@@ -4,9 +4,23 @@
     *, ::before, ::after {
         box-sizing: border-box;
     }
+
+    :any-link {
+        color: LinkText;
+    }
 }
 
 @layer base {
+    :root {
+        font-family: "Atkinson Hyperlegible Next", system-ui, sans-serif;
+        --font-mono: "Atkinson Hyperlegible Mono", "Courier New", monospace;
+    }
+
+    :is(input, select, button) {
+        font-family: inherit;
+        font-size: inherit;
+    }
+
     header {
         text-align: center;
         margin-block-end: 3rem;
@@ -43,10 +57,12 @@
         grid-template-columns: [portrait-start] max(125px, 35%) [portrait-end content-start] auto [content-end];
         column-gap: 8px;
         background-color: #fff;
-        font-family: Courier New, system-ui, sans-serif;
+        font-family: var(--font-mono);
         position: relative;
         border-block-end: 10px solid var(--party-color, #c0c0c0);
         box-shadow: 0 0 15px rgb(0 0 0 / 0.15);
+        max-inline-size: 500px;
+        justify-self: center;
     }
 
     .mp-card:not([hidden]) {
@@ -109,6 +125,9 @@
     .mp-portrait {
         display: block;
         inline-size: 100%;
+        block-size: 100%;
+        object-fit: cover;
+        object-position: top 0 left 50%;
     }
 }
 

--- a/views/_base.pug
+++ b/views/_base.pug
@@ -1,12 +1,16 @@
 doctype html
-html(lang=`${lang}-ca`)
+html.no-js(lang=`${lang}-ca`)
   head
     block head
       meta(charset="utf-8")
       meta(name="viewport" content="width=device-width,initial-scale=1")
       title=title ? `${title} | ${siteTitle}` : siteTitle
+      script document.documentElement.classList.remove("no-js")
+      link(rel="preconnect" href="https://fonts.googleapis.com")
+      link(rel="preconnect" href="https://fonts.gstatic.com" crossorigin)
       link(rel="stylesheet" href="/main.css")
       link(rel="stylesheet" href="/index.css")
+      link(rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Mono:ital,wght@0,200..800;1,200..800&family=Atkinson+Hyperlegible+Next:ital,wght@0,200..800;1,200..800&display=swap")
   body
     header
       nav

--- a/views/about.css
+++ b/views/about.css
@@ -1,9 +1,4 @@
 @layer page {
-    body {
-        font-family: system-ui, sans-serif;
-        font-feature-settings: "ss06";
-    }
-
     main {
         line-height: 1.6;
     }

--- a/views/index.css
+++ b/views/index.css
@@ -11,3 +11,87 @@
     max-inline-size: 100%;
     field-sizing: content;
 }
+
+.no-js .sorting-container {
+    padding-block-start: 0 !important;
+    label {
+        display: none;
+    }
+}
+
+.sorting-container {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 1rem;
+    row-gap: 0.5rem;
+    justify-content: center;
+    align-items: baseline;
+    padding-block-start: 1.5rem;
+    border-block-start: 2px solid hsl(from CanvasText h s l / 0.1);
+}
+
+label:has(select, input) {
+    font-weight: 600;
+    display: flex;
+    align-items: baseline;
+    column-gap: 0.25rem;
+}
+
+input[type="checkbox"] {
+    align-self: center;
+    margin: 0;
+}
+
+.totals {
+    max-inline-size: 30rem;
+    margin-inline: auto;
+    margin-block-end: 1rem;
+}
+
+.totals-table {
+    table-layout: fixed;
+    inline-size: 100%;
+    font-variant-numeric: tabular-nums;
+
+    tr:where([data-party="Bloc Québécois"]) { --party-color: #0088ce; }
+    tr:where([data-party="Conservative"]) { --party-color: #002395; }
+    tr:where([data-party="Green Party"]) { --party-color: #427a26; }
+    tr:where([data-party="Liberal"]) { --party-color: #d71920; }
+    tr:where([data-party="NDP"]) { --party-color: #ff5800; }
+    tr:where([data-party="Independent"]) { --party-color: #c0c0c0; }
+
+    th:first-of-type {
+        text-align: start;
+        padding-inline-end: 8px;
+
+        &:is(tbody [scope="row"]) {
+            border-inline-start: 4px solid var(--party-color);
+            padding-inline-start: 8px;
+        }
+
+        &:is(:is(thead, tfoot) th) {
+            padding-inline-start: 12px;
+        }
+    }
+
+    th:nth-of-type(2) { inline-size: 6ch; }
+    th:nth-of-type(3) { inline-size: 8ch; }
+    th:nth-of-type(4) { inline-size: 9ch; }
+    th:not(:first-of-type), td {
+        text-align: end;
+        padding-inline: 8px;
+    }
+
+    thead :is(th) {
+        border-block-end: 2px solid hsl(from CanvasText h s l / 0.3);
+        inline-size: fit-content;
+    }
+
+    tfoot :is(th, td) {
+        border-block-start: 2px solid hsl(from CanvasText h s l / 0.3);
+    }
+
+    tbody tr:nth-of-type(even) {
+        background-color: hsl(from Canvas h s calc(l * 0.9));
+    }
+}

--- a/views/index.css
+++ b/views/index.css
@@ -37,6 +37,28 @@ label:has(select, input) {
     column-gap: 0.25rem;
 }
 
+@supports selector(::picker(select)) {
+    select, ::picker(select) {
+        appearance: base-select;
+        background-color: Canvas;
+    }
+
+    ::picker(select) {
+        border-radius: 4px;
+        margin-block: 4px;
+    }
+
+    selectedcontent {
+        display: flex;
+        align-items: baseline;
+        gap: 0.25rem;
+    }
+
+    option {
+        gap: 0.25rem;
+    }
+}
+
 input[type="checkbox"] {
     align-self: center;
     margin: 0;
@@ -48,17 +70,18 @@ input[type="checkbox"] {
     margin-block-end: 1rem;
 }
 
+:where([data-party="Bloc Québécois"]) { --party-color: #0088ce; }
+:where([data-party="Conservative"]) { --party-color: #002395; }
+:where([data-party="Green Party"]) { --party-color: #427a26; }
+:where([data-party="Liberal"]) { --party-color: #d71920; }
+:where([data-party="NDP"]) { --party-color: #ff5800; }
+:where([data-party="Independent"]) { --party-color: #c0c0c0; }
+
 .totals-table {
     table-layout: fixed;
     inline-size: 100%;
     font-variant-numeric: tabular-nums;
 
-    tr:where([data-party="Bloc Québécois"]) { --party-color: #0088ce; }
-    tr:where([data-party="Conservative"]) { --party-color: #002395; }
-    tr:where([data-party="Green Party"]) { --party-color: #427a26; }
-    tr:where([data-party="Liberal"]) { --party-color: #d71920; }
-    tr:where([data-party="NDP"]) { --party-color: #ff5800; }
-    tr:where([data-party="Independent"]) { --party-color: #c0c0c0; }
 
     th:first-of-type {
         text-align: start;

--- a/views/index.js
+++ b/views/index.js
@@ -1,21 +1,35 @@
 const ALL = document.documentElement.lang === "fr-ca" ? "Toutes" : "All";
-const controls = [filterByParty, filterByProvince, filterByConstituency] = document.querySelectorAll("select");
+const controls = [filterByParty, filterByProvince, filterByConstituency] = Array.from(document.querySelectorAll("select"));
+const onlyLandlords = document.getElementById("only-landlords");
+const liveRegion = document.getElementById("live-region");
+
+controls.push(onlyLandlords);
 
 for (const control of controls) control.addEventListener("input", filterResults)
 
 function filterResults(mp) {
-    if (matchMedia("not (prefers-reduced-motion)").matches) filter();
-    document.startViewTransition?.(filter) ?? filter();
+    liveRegion.ariaBusy = "true";
+    if (matchMedia("(prefers-reduced-motion)").matches) filter();
+    const viewTransition = document.startViewTransition?.(filter) ?? filter();
+
+    viewTransition?.finished.then(updateLiveRegion) ?? requestAnimationFrame(updateLiveRegion);
 
     function filter() {
         for (const mp of document.querySelectorAll(".mp-card")) {
             mp.hidden = 
-                filterByParty.value === ALL && filterByProvince.value === ALL && filterByConstituency.value === ALL
+                filterByParty.value === ALL && filterByProvince.value === ALL && filterByConstituency.value === ALL && !onlyLandlords.checked
                 ? false
                 : (filterByProvince.value !== ALL && mp.dataset.province !== filterByProvince.value) ||
                   (filterByParty.value !== ALL && mp.dataset.party !== filterByParty.value) ||
-                  (filterByConstituency.value !== ALL && mp.dataset.constituency !== filterByConstituency.value);
+                  (filterByConstituency.value !== ALL && mp.dataset.constituency !== filterByConstituency.value) ||
+                  (onlyLandlords.checked && mp.dataset.landlord === "false");
         }
     }
-}
 
+    function updateLiveRegion() {
+        const visibleCards = Array.from(document.querySelectorAll(".mp-card:not([hidden])")).length;
+
+        liveRegion.textContent = `Showing ${visibleCards} ${filterByParty.value === ALL ? "" : `${filterByParty.value}`} MPs from ${filterByProvince.value === ALL ? "all provinces and territories" : filterByProvince.value}${onlyLandlords.checked ? " that are landlords" : ""}.`;
+        liveRegion.ariaBusy = "false";
+    }
+}

--- a/views/index.pug
+++ b/views/index.pug
@@ -36,8 +36,13 @@ block main
         label(for="party-select")
           | Party 
           select#party-select.filter-selector
+            button: selectedcontent
             each party in ["All", ...Array.from(parties, ([party]) => party).sort()]
-              option(value=party)=party
+              option(value=party)
+                div(data-party=party style="display: contents")
+                  svg(viewBox="0 0 20 20" width="1em" style="align-self: center")
+                    circle(r="10" cx="10" cy="10" fill="var(--party-color)")
+                  span=party
         label(for="province-select")
           | Province 
           select#province-select.filter-selector

--- a/views/index.pug
+++ b/views/index.pug
@@ -9,36 +9,58 @@ append foot
 block main
   .title
     h1=siteTitle
-    h4.landlord-count=`Liberal Party: ${partyCounts[0][0]} / ${partyCounts[0][1]} = ${((partyCounts[0][0] / partyCounts[0][1]) * 100).toFixed(2)}% of MP's are Landlords.`
-    h4.landlord-count=`Conservative Party: ${partyCounts[1][0]} / ${partyCounts[1][1]} = ${((partyCounts[1][0] / partyCounts[1][1]) * 100).toFixed(2)}% of  MP's are Landlords.`
-    h4.landlord-count=`NDP: ${partyCounts[2][0]} / ${partyCounts[2][1]} = ${((partyCounts[2][0] / partyCounts[2][1]) * 100).toFixed(2)}% of  MP's are Landlords.`
-    h4.landlord-count=`Bloc Québécois: ${partyCounts[3][0]} / ${partyCounts[3][1]} = ${((partyCounts[3][0] / partyCounts[3][1]) * 100).toFixed(2)}% of  MP's are Landlords.`
-    h4.landlord-count=`Green Party: ${partyCounts[4][0]} / ${partyCounts[4][1]} = ${((partyCounts[4][0] / partyCounts[4][1]) * 100).toFixed(2)}% of  MP's are Landlords.`
-    h4.landlord-count=`Independant: ${partyCounts[5][0]} / ${partyCounts[5][1]} = ${((partyCounts[5][0] / partyCounts[5][1]) * 100).toFixed(2)}% of  MP's are Landlords.`
-    h4.landlord-count=`${partyCounts[6][0]} / ${partyCounts[6][1]} = ${((partyCounts[6][0] / partyCounts[6][1]) * 100).toFixed(2)}% of all MP's are Landlords.`
     p All data sourced from the #[a(href=prciec.href)=prciec.label]
+  details.totals(open)
+    summary#table-details-label Landlords by party
+    table.totals-table(aria-labelledby="table-details-label")
+      thead
+        th Party
+        th(aria-sort="descending") #[span(aria-hidden="true") ▾] MPs
+        th Landlords
+        th Percentage
+      tbody
+        each data, party in Object.fromEntries(Array.from(parties).sort((a, b) => b[1].mps - a[1].mps))
+          tr(data-party=party)
+            th(scope="row")=party
+            td=data.mps
+            td=data.landlords
+            td=`${(data.landlords / data.mps * 100).toFixed(2)}%`
+      tfoot
+        th(scope="row") Totals
+        td=totalMps
+        td=totalLandlords
+        td=`${(totalLandlords / totalMps * 100).toFixed(2)}%`
   #root
     .mega-container
       .sorting-container
-        p.filter-text Select Party
-        select.filter-selector
-          each party in ["All", ...[...new Set(mps.map(mp => mp.party))].sort()]
-            option(value=party)=party
-        p.filter-text Select Province
-        select.filter-selector
-          each province in ["All", ...[...new Set(mps.map(mp => mp.province))].sort()]
-            option(value=province)=province
-        p.filter-text Select Riding
-        select.filter-selector
-          each constituency in ["All", ...mps.map(mp => mp.constituency).sort()]
-            option(value=constituency)=constituency
+        label(for="party-select")
+          | Party 
+          select#party-select.filter-selector
+            each party in ["All", ...Array.from(parties, ([party]) => party).sort()]
+              option(value=party)=party
+        label(for="province-select")
+          | Province 
+          select#province-select.filter-selector
+            each province in ["All", ...[...new Set(mps.map(mp => mp.province))].sort()]
+              option(value=province)=province
+        label(for="constituency-select")
+          | Riding 
+          select#constituency-select.filter-selector
+            each constituency in ["All", ...mps.map(mp => mp.constituency).sort()]
+              option(value=constituency)=constituency
+        label(for="only-landlords")
+          input#only-landlords(type="checkbox")
+          | Only landlords
+      #live-region.visually-hidden(aria-live="polite")
       ul.mp-cards-grid
         each mp in mps
           - const mpNameSlug = mp.name.toLowerCase().replaceAll(" ", "_");
-          li.mp-card(data-province=mp.province data-party=mp.party data-constituency=mp.constituency style=`view-transition-name: ${mpNameSlug}`)
+          li.mp-card(data-province=mp.province data-party=mp.party data-constituency=mp.constituency data-landlord=JSON.stringify(mp.landlord) style=`view-transition-name: ${mpNameSlug}`)
             img.mp-portrait(src=`/images/mp_images/${mp.image_name}` alt="" loading="lazy")
             .mp-card-content
-              h2.mp-card-title=mp.name
+              h2.mp-card-title
+                span(translate="no")=mp.name
+                strong(style="font-weight: 500;") #{mp.landlord ? " is" : " is not"} a landlord
               dl.mp-card-details
                 dt.visually-hidden Party
                 dd=mp.party


### PR DESCRIPTION
Builds on #28. This does quite a bit.

- Use one aggregate query for the MP data with the sheet data.
- Since we have the landlord info with the MP info via that query, I added a landlord filter for the cards.
- Changes the MP/landlord count to be a table.
- Makes the image fit correctly on the cards if they happen to grow in size due to long riding names.
- Adds a live region for the filter updates. Tested with VoiceOver on macOS and NVDA on Windows.
- Fixes some confusion I introduced again with the reduced motion stuff.
- Hides the filter when there’s no JS available.
- Uses Atkinson Hyperlegible Mono and Next as fonts for the site.
  - I’ll need to optimize these (i.e. self-host and maybe not use the variable fonts since they’re larger).