### PR TITLE
Make table a scroll container for small screens

### DIFF
--- a/views/index.css
+++ b/views/index.css
@@ -3,12 +3,12 @@
 }
 
 :root {
-    scrollbar-gutter: stable;
+    scrollbar-gutter: stable both-edges;
 }
 
 .sorting-container select {
     /* Fallback for field-sizing */
-    max-inline-size: 100%;
+    max-inline-size: 20ch;
     field-sizing: content;
 }
 
@@ -77,15 +77,24 @@ input[type="checkbox"] {
 :where([data-party="NDP"]) { --party-color: #ff5800; }
 :where([data-party="Independent"]) { --party-color: #c0c0c0; }
 
+.totals-table-wrapper {
+    min-inline-size: 100%;
+    overflow: auto;
+    position: relative;
+    overscroll-behavior: none;
+}
+
 .totals-table {
     table-layout: fixed;
-    inline-size: 100%;
     font-variant-numeric: tabular-nums;
-
 
     th:first-of-type {
         text-align: start;
         padding-inline-end: 8px;
+        min-inline-size: 12ch;
+        inline-size: 100%;
+        position: sticky;
+        inset-inline-start: 2px;
 
         &:is(tbody [scope="row"]) {
             border-inline-start: 4px solid var(--party-color);
@@ -114,7 +123,17 @@ input[type="checkbox"] {
         border-block-start: 2px solid hsl(from CanvasText h s l / 0.3);
     }
 
-    tbody tr:nth-of-type(even) {
-        background-color: hsl(from Canvas h s calc(l * 0.9));
+    tbody {
+        tr:nth-of-type(odd) :is(td, th) {
+            background-color: Canvas;
+        }
+
+        tr:nth-of-type(even) :is(td, th) {
+            background-color: #f2f2f2;
+        }
+    }
+
+    :is(thead, tfoot) :is(th, td) {
+        background-color: #f2f2f2;
     }
 }

--- a/views/index.pug
+++ b/views/index.pug
@@ -12,24 +12,25 @@ block main
     p All data sourced from the #[a(href=prciec.href)=prciec.label]
   details.totals(open)
     summary#table-details-label Landlords by party
-    table.totals-table(aria-labelledby="table-details-label")
-      thead
-        th Party
-        th(aria-sort="descending") #[span(aria-hidden="true") ▾] MPs
-        th Landlords
-        th Percentage
-      tbody
-        each data, party in Object.fromEntries(Array.from(parties).sort((a, b) => b[1].mps - a[1].mps))
-          tr(data-party=party)
-            th(scope="row")=party
-            td=data.mps
-            td=data.landlords
-            td=`${(data.landlords / data.mps * 100).toFixed(2)}%`
-      tfoot
-        th(scope="row") Totals
-        td=totalMps
-        td=totalLandlords
-        td=`${(totalLandlords / totalMps * 100).toFixed(2)}%`
+    .totals-table-wrapper
+      table.totals-table(aria-labelledby="table-details-label")
+        thead
+          th Party
+          th(aria-sort="descending") #[span(aria-hidden="true") ▾]&nbsp;MPs
+          th Landlords
+          th Percentage
+        tbody
+          each data, party in Object.fromEntries(Array.from(parties).sort((a, b) => b[1].mps - a[1].mps))
+            tr(data-party=party)
+              th(scope="row")=party
+              td=data.mps
+              td=data.landlords
+              td=`${(data.landlords / data.mps * 100).toFixed(2)}%`
+        tfoot
+          th(scope="row") Totals
+          td=totalMps
+          td=totalLandlords
+          td=`${(totalLandlords / totalMps * 100).toFixed(2)}%`
   #root
     .mega-container
       .sorting-container


### PR DESCRIPTION
Makes the table a scroll container for smaller screens. The first column sticks to the left edge. Also, fixed the selects causing overflow for Safari/Firefox.