### PR TITLE
Add fallback for field-sizing

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -17,6 +17,12 @@
     select {
         field-sizing: content;
     }
+
+    @supports not (field-sizing: content) {
+        select {
+            inline-size: clamp(6rem, 60cqi, 12rem);
+        }
+    }
 }
 
 @layer base {


### PR DESCRIPTION
Currently, on mobile devices that do not support `field-sizing: content` (i.e. iOS browsers, Firefox on Android), the filters are centred and in the case of the constituency filter, it’s clipped on the left side. This adds a flexible inline-size for the selects that avoids content loss.
