### PR TITLE
Format percentages based on locale

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,11 @@ app.use("/:lang", (req, res, next) => {
     req.collator = new Intl.Collator(`${lang}-ca`).compare;
 
     res.locals.lang = lang;
+    res.locals.formatPercentage = new Intl.NumberFormat(`${lang}-ca`, {
+        style: "percent",
+        trailingZeroDisplay: "stripIfInteger",
+        minimumFractionDigits: 2,
+    }).format;
 
     next();
 });

--- a/views/member-list.pug
+++ b/views/member-list.pug
@@ -69,14 +69,14 @@ block main
                 th(scope="row")=party
                 td=memberCount
                 td=landlordCount
-                td #{(landlordCount / memberCount * 100).toFixed(2)}%
+                td=formatPercentage(landlordCount / memberCount)
           tfoot
             - const memberCount = members.length
             - const landlordCount = members.filter(member => member.landlord).length
             th(scope="row")=t("allParties")
             td=memberCount
             td=landlordCount
-            td #{(landlordCount / memberCount * 100).toFixed(2)}%
+            td=formatPercentage(landlordCount / memberCount)
 
   form(name="filters")
     if parties


### PR DESCRIPTION
This uses the `Intl.NumberFormat` API to format the percentages in the table based on locale and avoids trailing zeros for integers (i.e. usually `100%` or `0%`). For French, the percentages are know formatted like: `100 %` or `47,06 %`.
